### PR TITLE
Smaller final docker image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+build
 dist
 cabal-dev
 *.o

--- a/Build.dockerfile
+++ b/Build.dockerfile
@@ -1,0 +1,24 @@
+FROM haskell:7.10
+MAINTAINER Pat Bribin <pat@codeclimate.com>
+
+WORKDIR /home/app
+
+RUN cabal update
+RUN cabal install \
+  Glob \
+  aeson \
+  aeson \
+  bytestring \
+  containers \
+  directory \
+  haskell-src-exts \
+  hlint \
+  text
+
+COPY engine.cabal /home/app/engine.cabal
+RUN cabal install --dependencies-only
+
+COPY LICENSE /home/src/app
+COPY src /home/app/src
+COPY main.hs /home/app/main.hs
+RUN cabal build

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,31 +1,14 @@
-FROM haskell:7.10
+FROM alpine:3.3
 MAINTAINER Pat Bribin <pat@codeclimate.com>
 
-RUN useradd -u 9000 -d /home/app -m app
+RUN adduser -u 9000 -h /home/app -D app
 USER app
 WORKDIR /home/app
 
-RUN cabal update
-RUN cabal install \
-  Glob \
-  aeson \
-  aeson \
-  bytestring \
-  containers \
-  directory \
-  haskell-src-exts \
-  hlint \
-  text
-
-COPY engine.cabal /home/app/engine.cabal
-RUN cabal install --dependencies-only
-
-COPY src /home/app/src
-COPY main.hs /home/app/main.hs
+COPY build/ /home/app/
 COPY LICENSE /home/app/LICENSE
-RUN cabal build
 
 VOLUME /code
 WORKDIR /code
 
-ENTRYPOINT ["/home/app/dist/build/engine/engine"]
+ENTRYPOINT ["/home/app/codeclimate-hlint"]

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,16 @@
+IMAGE_NAME ?= codeclimate/codeclimate-hlint
+
 build:
-	docker build --tag codeclimate/codeclimate-hlint .
+	mkdir -p build
+	docker build --tag codeclimate/codeclimate-hlint-build --file Build.dockerfile .
+	docker run --rm --volume "$(PWD)/build:/build" codeclimate/codeclimate-hlint-build cp /home/app/dist/build/engine/engine /build/codeclimate-hlint
+	docker run --rm --volume "$(PWD)/build:/build" codeclimate/codeclimate-hlint-build cp -r /root/.cabal/share/x86_64-linux-ghc-7.10.2/hlint-1.9.26/ /build/hlint-src
+	docker build --tag $(IMAGE_NAME) .
 
 check: build
 	docker run \
 	  --rm --volume $(PWD):/code:ro \
-	  codeclimate/codeclimate-hlint \
+	  $(IMAGE_NAME) \
 	    | sed 's/\x00/,/g; s/,$$//; s/.*/[&]/' \
 	    | python -mjson.tool
 

--- a/engine.cabal
+++ b/engine.cabal
@@ -28,7 +28,7 @@ library
 executable engine
   default-language:     Haskell2010
   main-is:              main.hs
-  ghc-options:          -Wall -Werror
+  ghc-options:          -Wall -Werror -static -optl-static -optl-pthread
   build-depends:        base
                       , engine
                       , aeson


### PR DESCRIPTION
Split the build process into 2 parts: the first part does the build in
a docker image with the full haskell toolchain, etc. The second part
copies the necessary files for actually running (a statically compiled
binary & the HLint source) into a much smaller docker image.

The engine source had to be adjusted for this a bit: HLint reads its own
source code for default configuration, and we need to change the path it
looks in.
